### PR TITLE
Improve pill style

### DIFF
--- a/static/sidepanel.css
+++ b/static/sidepanel.css
@@ -87,7 +87,10 @@ h1 {
     border-radius: 999px;
     width: 100%;
     box-sizing: border-box;
-    margin: 20px 0
+    margin: 20px 0;
+    position: sticky;
+    top: 20px;
+    box-shadow: 1px 7px 20px 16px var(--bg);
 }
 
 #tab-favicon {


### PR DESCRIPTION
This pull request introduces a small UI improvement to the side panel header. The change makes the `h1` header sticky, ensuring it remains visible at the top of the panel as users scroll.

UI enhancement:

* Made the `h1` header in `static/sidepanel.css` sticky with a top offset and added a box shadow for better visibility.